### PR TITLE
Expose Authorization header on cors

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -9,6 +9,11 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins '*'
 
-    resource '*', headers: :any, methods: %i[get post put patch delete options head]
+    resource(
+      '*',
+      headers: :any,
+      methods: %i[get post put patch delete options head],
+      expose: %w[Authorization]
+    )
   end
 end


### PR DESCRIPTION
#### What?

Expose `Authorization` header on cors

#### Why?

This way all apps that will consume it, can keep the `bearer` token returned of the `sign_in` flow

#### How it has been tested?

Ensuring if a `sign_in` process will have the header available for the frontend.
