### PR TITLE
validate the presence of company's code attribute

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,5 @@
 class Company < ApplicationRecord
-  validates :name, :cnpj, :active, presence: true
+  validates :name, :cnpj, :code, :active, presence: true
   validates :cnpj, :code, uniqueness: { case_sensitive: false }
 
   has_many :company_users, dependent: :destroy

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Company, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:cnpj) }
+    it { is_expected.to validate_presence_of(:code) }
     it { is_expected.to validate_presence_of(:active) }
 
     it { is_expected.to validate_uniqueness_of(:cnpj).case_insensitive }


### PR DESCRIPTION
#### What?

- Add a validation method to check the presence of the company's code attribute.

#### Why?

- Since it has uniqueness validation, it must be required, otherwise, just one company will be able to have an empty ('') code attribute.

#### How it has been tested?

- Unit tests with RSpec.

Closes #28 
