### PR TITLE
Adjust validation of company active field

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,6 +1,7 @@
 class Company < ApplicationRecord
-  validates :name, :cnpj, :code, :active, presence: true
+  validates :name, :cnpj, :code, presence: true
   validates :cnpj, :code, uniqueness: { case_sensitive: false }
+  validates :active, inclusion: { in: [true, false] }
 
   has_many :company_users, dependent: :destroy
   has_many :users, through: :company_users

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Company, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:cnpj) }
     it { is_expected.to validate_presence_of(:code) }
-    it { is_expected.to validate_presence_of(:active) }
+
+    it { is_expected.to validate_inclusion_of(:active).in_array([true, false]) }
 
     it { is_expected.to validate_uniqueness_of(:cnpj).case_insensitive }
     it { is_expected.to validate_uniqueness_of(:code).case_insensitive }


### PR DESCRIPTION
Closes: https://github.com/comarev/comarev/issues/33

#### What?

Adjust Company `active` field validation to use `inclusion` instead of `presence`

#### Why?

Since it's a boolean field, we can't validate it with the `presence` matcher. According to [this](https://stackoverflow.com/a/18685484/12934208) the `presence` matcher checks that the attribute is not `Object#blank?`

#### How it has been tested?

Trying to create a company with active field false
