### PR TITLE
Add update action to InvoicesController

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -11,6 +11,13 @@ class InvoicesController < ApplicationController
     render json: @invoice, status: :created
   end
 
+  def update
+    @invoice = Invoice.find(params[:id])
+    @invoice.update!(invoice_params)
+
+    render json: @invoice, status: :ok
+  end
+
   private
 
   def invoice_params


### PR DESCRIPTION
Closes: https://github.com/comarev/comarev/issues/19

#### What?

Add `update` action to InvoicesController

#### Why?

This will allow admins to update invoices.

#### How it has been tested?

Make a PATCH request to: `/invoices/:id,` with a body like:

```json
{
  "invoice": {
    "paid": true,
    "status": "finished"
  }
}
```
you should receive a response like:
```json
{
  "id": 1,
  "user_id": 2,
  "amount": 50.45,
  "paid": true,
  "status": "finished",
  "created_at": "2021-11-19T17:48:01.768Z",
  "updated_at": "2021-11-24T22:59:56.321Z"
}
```