### PR TITLE
Company code attr auto generated

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -39,7 +39,8 @@ class CompaniesController < ApplicationController
   end
 
   def company_params
-    company_params = %i[name cnpj address phone active code discount].push(user_ids: [])
+    company_params = %i[name cnpj address phone active discount].push(user_ids: [])
+
     params.require(:company).permit(company_params)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,8 +1,15 @@
 class Company < ApplicationRecord
-  validates :name, :cnpj, :code, presence: true
+  validates :name, :cnpj, presence: true
   validates :cnpj, :code, uniqueness: { case_sensitive: false }
-  validates :active, inclusion: { in: [true, false] }
 
   has_many :company_users, dependent: :destroy
   has_many :users, through: :company_users
+
+  before_validation :assign_code
+
+  private
+
+  def assign_code
+    self.code ||= SecureRandom.hex(10)
+  end
 end

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     address { FFaker::Address.street_name }
     phone { FFaker::PhoneNumberBR.phone_number }
     active { true }
-    code { FFaker::PhoneNumber.phone_number }
     discount { 10 }
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe Company, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:cnpj) }
-    it { is_expected.to validate_presence_of(:code) }
-
-    it { is_expected.to validate_inclusion_of(:active).in_array([true, false]) }
 
     it { is_expected.to validate_uniqueness_of(:cnpj).case_insensitive }
     it { is_expected.to validate_uniqueness_of(:code).case_insensitive }
@@ -16,5 +13,17 @@ RSpec.describe Company, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_many(:users) }
+  end
+
+  describe 'callbacks' do
+    describe 'assign_code' do
+      subject { company.code }
+
+      let(:company) { build(:company, code: nil) }
+
+      before { company.save }
+
+      it { is_expected.to be_present }
+    end
   end
 end


### PR DESCRIPTION
closes: https://github.com/comarev/comarev/issues/37

#### What?

- add auto-generated code for companies
- remove unnecessary spec about a boolean column

#### Why?

- we don't need to pass a code when creating a new company
- to solve the following message from shoulda_matchers:

```
You are using `validate_inclusion_of` to assert that a boolean column
allows boolean values and disallows non-boolean ones. Be aware that it
is not possible to fully test this, as boolean columns will
automatically convert non-boolean values to boolean ones. Hence, you
should consider removing this test.
```
#### How it has been tested?

- Create a new company without passing the code attr, and check if it's present
