### PR TITLE
Resolve some deprecation warnings and Improve rubocop settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 .tool-versions
 /coverage
 /config/database.yml
+.prettierrc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,14 +4,14 @@ require:
 
 AllCops:
   Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'script/**/*'
-    - 'bin/**/*'
-    - 'tmp/**/*'
-    - 'vendor/**/*'
-    - 'log/**/*'
-    - 'node_modules/**/*'
+    - "db/**/*"
+    - "config/**/*"
+    - "script/**/*"
+    - "bin/**/*"
+    - "tmp/**/*"
+    - "vendor/**/*"
+    - "log/**/*"
+    - "node_modules/**/*"
     - !ruby/regexp /old_and_unused\.rb$/
 
 Gemspec/DateAssignment:
@@ -97,6 +97,8 @@ Rails/EagerEvaluationLogMessage:
   Enabled: true
 Rails/ExpandedDateRange:
   Enabled: true
+Rails/FilePath:
+  Enabled: false
 Rails/FindById:
   Enabled: true
 Rails/I18nLocaleAssignment:
@@ -143,8 +145,13 @@ RSpec/ImplicitSubject:
   Enabled: false
 RSpec/Rails/AvoidSetupHook:
   Enabled: true
+RSpec/LetSetup:
+  Enabled: true
 RSpec/MultipleExpectations:
   Enabled: false
+RSpec/NestedGroups:
+  Enabled: true
+  Max: 5
 Style/AndOr:
   Enabled: false
 Style/ClassAndModuleChildren:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,6 +139,8 @@ Rails/WhereNot:
   Enabled: true
 RSpec/IdenticalEqualityAssertion:
   Enabled: true
+RSpec/ImplicitSubject:
+  Enabled: false
 RSpec/Rails/AvoidSetupHook:
   Enabled: true
 RSpec/MultipleExpectations:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,80 +1,186 @@
+require:
+  - rubocop-rails
+  - rubocop-rspec
+
 AllCops:
   Exclude:
-    - "db/**/*"
-    - "config/**/*"
-    - "script/**/*"
-    - "bin/**/*"
-    - "tmp/**/*"
-    - "vendor/**/*"
-    - "log/**/*"
-    - "node_modules/**/*"
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+    - 'bin/**/*'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+    - 'log/**/*'
+    - 'node_modules/**/*'
     - !ruby/regexp /old_and_unused\.rb$/
 
+Gemspec/DateAssignment:
+  Enabled: true
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
-
 Layout/ArrayAlignment:
   EnforcedStyle: with_fixed_indentation
-
 Layout/FirstArrayElementIndentation:
   Enabled: false
-
 Layout/FirstHashElementIndentation:
   Enabled: false
-
 Layout/HashAlignment:
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: ignore_implicit
-
 Layout/LineLength:
   Max: 99
-
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
-
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
-
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
-
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+Lint/AmbiguousAssignment:
+  Enabled: true
+Lint/DeprecatedConstants:
+  Enabled: true
+Lint/DuplicateBranch:
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+Lint/EmptyBlock:
+  Enabled: true
+Lint/EmptyClass:
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+Lint/NumberedParameterAssignment:
+  Enabled: true
+Lint/OrAssignmentToConstant:
+  Enabled: true
+Lint/RedundantDirGlobSort:
+  Enabled: true
+Lint/SymbolConversion:
+  Enabled: true
+Lint/ToEnumArguments:
+  Enabled: true
+Lint/TripleQuotes:
+  Enabled: true
+Lint/UnexpectedBlockArity:
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
 Metrics/AbcSize:
   Max: 25
-
 Metrics/BlockLength:
   Max: 99
   Exclude:
     - spec/**/*
-
 Metrics/MethodLength:
   CountComments: false
   Max: 90
-
 Naming/PredicateName:
   Enabled: false
-
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+Rails/AddColumnIndex:
+  Enabled: true
+Rails/AfterCommitOverride:
+  Enabled: true
+Rails/AttributeDefaultBlockValue:
+  Enabled: true
+Rails/CompactBlank:
+  Enabled: true
+Rails/DurationArithmetic:
+  Enabled: true
+Rails/EagerEvaluationLogMessage:
+  Enabled: true
+Rails/ExpandedDateRange:
+  Enabled: true
+Rails/FindById:
+  Enabled: true
+Rails/I18nLocaleAssignment:
+  Enabled: true
+Rails/Inquiry:
+  Enabled: true
+Rails/MailerName:
+  Enabled: true
+Rails/MatchRoute:
+  Enabled: true
+Rails/NegateInclude:
+  Enabled: true
+Rails/Pluck:
+  Enabled: true
+Rails/PluckInWhere:
+  Enabled: true
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: true
+Rails/RedundantTravelBack:
+  Enabled: true
+Rails/RenderInline:
+  Enabled: true
+Rails/RenderPlainText:
+  Enabled: true
+Rails/RootJoinChain:
+  Enabled: true
+Rails/ShortI18n:
+  Enabled: true
+Rails/SquishedSQLHeredocs:
+  Enabled: true
+Rails/TimeZoneAssignment:
+  Enabled: true
+Rails/UnusedIgnoredColumns:
+  Enabled: true
+Rails/WhereEquals:
+  Enabled: true
+Rails/WhereExists:
+  Enabled: true
+Rails/WhereNot:
+  Enabled: true
+RSpec/IdenticalEqualityAssertion:
+  Enabled: true
+RSpec/Rails/AvoidSetupHook:
+  Enabled: true
+RSpec/MultipleExpectations:
+  Enabled: false
 Style/AndOr:
   Enabled: false
-
 Style/ClassAndModuleChildren:
   Enabled: false
-
 Style/Documentation:
   Enabled: false
-
 Style/EachWithObject:
   Enabled: false
-
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: never
-
 Style/RedundantReturn:
   Enabled: true
-
 Style/Semicolon:
   AllowAsExpressionSeparator: true
-
 Style/Encoding:
   Enabled: false
+Style/ArgumentsForwarding:
+  Enabled: true
+Style/CollectionCompact:
+  Enabled: true
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
+Style/EndlessMethod:
+  Enabled: true
+Style/HashConversion:
+  Enabled: true
+Style/HashExcept:
+  Enabled: true
+Style/IfWithBooleanLiteralBranches:
+  Enabled: true
+Style/NegatedIfElseCondition:
+  Enabled: true
+Style/NilLambda:
+  Enabled: true
+Style/RedundantArgument:
+  Enabled: true
+Style/StringChars:
+  Enabled: true
+Style/SwapValues:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 5.0.0'
   gem 'rubocop'
+  gem 'rubocop-rails'
+  gem 'rubocop-rspec'
   gem 'shoulda-matchers', '~> 4.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,13 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    rubocop-rails (2.13.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
+    rubocop-rspec (2.4.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.0)
       ffi (~> 1.12)
@@ -340,6 +347,8 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails (~> 5.0.0)
   rubocop
+  rubocop-rails
+  rubocop-rspec
   shoulda-matchers (~> 4.0)
   simplecov
   spring

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -21,7 +21,7 @@ class CompaniesController < ApplicationController
   end
 
   def update
-    @company.update_attributes!(permitted_attributes(@company))
+    @company.update!(permitted_attributes(@company))
 
     render json: @company, status: :ok
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user.update_attributes!(permitted_attributes(@user))
+    @user.update!(permitted_attributes(@user))
 
     render json: @user, status: :ok
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   validates :email, :cpf, uniqueness: true
   validates :email, :full_name, :cellphone, :address, :cpf, presence: true
 
-  has_many :company_users
+  has_many :company_users, dependent: :destroy
   has_many :companies, through: :company_users
 
   def picture_url

--- a/db/migrate/20220202220750_add_index_for_company_cnpj.rb
+++ b/db/migrate/20220202220750_add_index_for_company_cnpj.rb
@@ -1,0 +1,6 @@
+class AddIndexForCompanyCnpj < ActiveRecord::Migration[6.0]
+  def change
+    add_index :companies, :cnpj, unique: true
+    add_index :companies, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_26_221043) do
+ActiveRecord::Schema.define(version: 2022_02_02_220750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 2021_10_26_221043) do
     t.integer "discount"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["cnpj"], name: "index_companies_on_cnpj", unique: true
+    t.index ["code"], name: "index_companies_on_code", unique: true
   end
 
   create_table "company_users", force: :cascade do |t|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,5 +16,6 @@ RSpec.describe User, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_many(:companies) }
+    it { is_expected.to have_many(:company_users).dependent(:destroy) }
   end
 end

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -5,7 +5,7 @@ describe CompanyPolicy, type: :policy do
 
   let(:new_company) { build_stubbed(:company) }
 
-  context 'for a regular user' do
+  context 'when a regular user' do
     let(:user) { build_stubbed(:user) }
 
     it { is_expected.to authorize(:index) }
@@ -15,7 +15,7 @@ describe CompanyPolicy, type: :policy do
     it { is_expected.not_to authorize(:update) }
   end
 
-  context 'for an admin user' do
+  context 'when an admin user' do
     let(:user) { build_stubbed(:user, :admin) }
 
     it { is_expected.to authorize(:create) }
@@ -25,11 +25,11 @@ describe CompanyPolicy, type: :policy do
     it { is_expected.to authorize(:update) }
   end
 
-  context 'for manager user' do
+  context 'when manager user' do
     let(:user) { create(:user) }
     let(:new_company) { create(:company) }
 
-    let!(:company_user) do
+    before do
       create(:company_user, :manager, company: new_company, user: user)
     end
 
@@ -40,11 +40,11 @@ describe CompanyPolicy, type: :policy do
     it { is_expected.not_to authorize(:destroy) }
   end
 
-  context 'for regular user from the company' do
+  context 'when regular user from the company' do
     let(:user) { create(:user) }
     let(:new_company) { create(:company) }
 
-    let!(:company_user) do
+    before do
       create(:company_user, :regular, company: new_company, user: user)
     end
 
@@ -58,7 +58,7 @@ describe CompanyPolicy, type: :policy do
   describe '#permitted_attributes' do
     subject { described_class.new(user, company).permitted_attributes }
 
-    context 'for admin user' do
+    context 'when admin user' do
       let(:company) { build_stubbed(:company) }
       let(:user) { create(:user, :admin) }
 
@@ -69,11 +69,11 @@ describe CompanyPolicy, type: :policy do
       end
     end
 
-    context 'for manager user' do
+    context 'when manager user' do
       let(:company) { build_stubbed(:company) }
       let(:user) { create(:user) }
 
-      let!(:company_user) do
+      before do
         build_stubbed(:company_user, :manager, company: company, user: user)
       end
 
@@ -82,11 +82,11 @@ describe CompanyPolicy, type: :policy do
       end
     end
 
-    context 'for regular user' do
+    context 'when regular user' do
       let(:company) { build_stubbed(:company) }
       let(:user) { create(:user) }
 
-      let!(:company_user) do
+      before do
         build_stubbed(:company_user, :regular, company: company, user: user)
       end
 
@@ -112,7 +112,7 @@ describe CompanyPolicy, type: :policy do
     context 'when other user' do
       let(:user) { create(:user) }
 
-      let!(:relation) { create(:company_user, :regular, company: company1, user: user) }
+      before { create(:company_user, :regular, company: company1, user: user) }
 
       it { is_expected.to include(company1) }
       it { is_expected.not_to include(company2) }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -5,7 +5,7 @@ describe UserPolicy do
 
   let(:new_user) { build_stubbed(:user) }
 
-  context 'for a regular user' do
+  context 'when a regular user' do
     let(:user) { build_stubbed(:user) }
 
     it { is_expected.not_to authorize(:create) }
@@ -13,7 +13,7 @@ describe UserPolicy do
     it { is_expected.not_to authorize(:index) }
   end
 
-  context 'for an admin user' do
+  context 'when an admin user' do
     let(:user) { build_stubbed(:user, :admin) }
 
     it { is_expected.to authorize(:create) }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe UserPolicy do
-  subject { UserPolicy.new(user, new_user) }
+  subject { described_class.new(user, new_user) }
 
   let(:new_user) { build_stubbed(:user) }
 

--- a/spec/requests/company_spec.rb
+++ b/spec/requests/company_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Company, type: :request do
   let(:user) { create(:user, :admin) }
-  let(:headers) { { "Authorization": sign_in(user) } }
+  let(:headers) { { Authorization: sign_in(user) } }
 
   describe 'GET /index' do
     subject(:fetch_companies) do
@@ -63,10 +63,11 @@ RSpec.describe Company, type: :request do
   end
 
   describe 'POST /create' do
-    before { headers }
     subject(:create_company) do
       post companies_path, params: { company: company_params }, headers: headers
     end
+
+    before { headers }
 
     context 'with valid data' do
       let(:company_params) { attributes_for(:company, name: 'Tesla') }
@@ -80,7 +81,7 @@ RSpec.describe Company, type: :request do
       it 'creates the new record' do
         expect do
           create_company
-        end.to change(Company, :count).by(1)
+        end.to change(described_class, :count).by(1)
       end
 
       it 'returns the expected response body' do
@@ -100,7 +101,7 @@ RSpec.describe Company, type: :request do
       end
 
       it 'does not create the new record' do
-        expect { create_company }.not_to change(Company, :count)
+        expect { create_company }.not_to change(described_class, :count)
       end
 
       it 'returns the expected response body' do
@@ -133,12 +134,13 @@ RSpec.describe Company, type: :request do
   end
 
   describe 'PATCH /update' do
-    before { headers }
     subject(:update_company) do
       patch company_path(target_company),
         params: company_params,
         headers: headers
     end
+
+    before { headers }
 
     context 'when the company exists' do
       let(:target_company) { create(:company) }
@@ -155,7 +157,7 @@ RSpec.describe Company, type: :request do
         it 'returns the correct 200 response code' do
           expect do
             update_company
-          end.to change(Company, :count).by(1)
+          end.to change(described_class, :count).by(1)
 
           expect(response).to have_http_status(:ok)
         end

--- a/spec/requests/invoice_spec.rb
+++ b/spec/requests/invoice_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Invoice, type: :request do
   let(:user) { create(:user, :admin) }
-  let(:headers) { { "Authorization": sign_in(user) } }
+  let(:headers) { { Authorization: sign_in(user) } }
 
   describe 'GET #index' do
     it 'returns http_status ok' do
@@ -29,7 +29,7 @@ RSpec.describe Invoice, type: :request do
       end
 
       it 'creates the new record' do
-        expect { create_invoice }.to change(Invoice, :count).by(1)
+        expect { create_invoice }.to change(described_class, :count).by(1)
       end
 
       it 'returns the expected response body' do
@@ -49,7 +49,7 @@ RSpec.describe Invoice, type: :request do
       end
 
       it 'does not create the new record' do
-        expect { create_invoice }.not_to change(Invoice, :count)
+        expect { create_invoice }.not_to change(described_class, :count)
       end
 
       it 'returns the expected response body' do

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :request do
   let(:user) { create(:user, :admin) }
-  let(:headers) { { "Authorization": sign_in(user) } }
+  let(:headers) { { Authorization: sign_in(user) } }
 
   describe 'GET /index' do
     subject(:fetch_users) do
@@ -67,10 +67,11 @@ RSpec.describe User, type: :request do
   end
 
   describe 'POST /create' do
-    before { headers }
     subject(:create_user) do
       post users_path, params: { user: user_params }, headers: headers
     end
+
+    before { headers }
 
     context 'with valid data' do
       let(:user_params) { attributes_for(:user, full_name: 'Mary Jane') }
@@ -84,7 +85,7 @@ RSpec.describe User, type: :request do
       it 'creates the new record' do
         expect do
           create_user
-        end.to change(User, :count).by(1)
+        end.to change(described_class, :count).by(1)
       end
 
       it 'returns the expected response body' do
@@ -104,7 +105,7 @@ RSpec.describe User, type: :request do
       end
 
       it 'does not create the new record' do
-        expect { create_user }.not_to change(User, :count)
+        expect { create_user }.not_to change(described_class, :count)
       end
 
       it 'returns the expected response body' do
@@ -137,12 +138,13 @@ RSpec.describe User, type: :request do
   end
 
   describe 'PATCH /update' do
-    before { headers }
     subject(:update_user) do
       patch user_path(target_user),
         params: user_params,
         headers: headers
     end
+
+    before { headers }
 
     context 'when the user exists' do
       let(:target_user) { create(:user) }
@@ -159,7 +161,7 @@ RSpec.describe User, type: :request do
         it 'returns the correct 200 response code' do
           expect do
             update_user
-          end.to change(User, :count).by(1)
+          end.to change(described_class, :count).by(1)
 
           expect(response).to have_http_status(:ok)
         end

--- a/spec/support/pundit_matcher.rb
+++ b/spec/support/pundit_matcher.rb
@@ -3,11 +3,11 @@ RSpec::Matchers.define :authorize do |action|
     policy.public_send("#{action}?")
   end
 
-  failure_message_for_should do |policy|
+  failure_message do |policy|
     "#{policy.class} does not permit #{action} on #{policy.record} for #{policy.user.inspect}."
   end
 
-  failure_message_for_should_not do |policy|
+  failure_message_when_negated do |policy|
     "#{policy.class} does not forbid #{action} on #{policy.record} for #{policy.user.inspect}."
   end
 end


### PR DESCRIPTION
#### What?

- resolve some `pundit` matchers and `update_attributes` deprecation warnings
- add `rubocop-rails` and `rubocop-rspec` gems

#### Why?

- to improve our rubocop settings, and get a better codebase

#### How it has been tested?

- Running `bundle exec rubocop`
