### PR TITLE
Now CompaniesController can receive manager_ids and regular_ids

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,6 +139,8 @@ Rails/WhereExists:
   Enabled: true
 Rails/WhereNot:
   Enabled: true
+RSpec/ExampleLength:
+  Enabled: false
 RSpec/IdenticalEqualityAssertion:
   Enabled: true
 RSpec/ImplicitSubject:

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -39,7 +39,8 @@ class CompaniesController < ApplicationController
   end
 
   def company_params
-    company_params = %i[name cnpj address phone active discount].push(user_ids: [])
+    company_params = %i[name cnpj address phone active discount]
+      .push(manager_ids: [], regular_ids: [])
 
     params.require(:company).permit(company_params)
   end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -5,6 +5,14 @@ class Company < ApplicationRecord
   has_many :company_users, dependent: :destroy
   has_many :users, through: :company_users
 
+  has_many :managers,
+    -> { where(company_users: { role: :manager }) },
+    through: :company_users, source: :user
+
+  has_many :regulars,
+    -> { where(company_users: { role: :regular }) },
+    through: :company_users, source: :user
+
   before_validation :assign_code
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   has_many :company_users, dependent: :destroy
   has_many :companies, through: :company_users
 
+  scope :admins, -> { where(admin: true) }
+
   def picture_url
     return nil if avatar.file.nil?
 

--- a/app/serializers/company_serializer.rb
+++ b/app/serializers/company_serializer.rb
@@ -7,7 +7,9 @@ class CompanySerializer < ActiveModel::Serializer
     :code,
     :discount,
     :active,
-    :users,
     :created_at,
     :updated_at
+
+  has_many :managers, serializer: UserSerializer
+  has_many :regulars, serializer: UserSerializer
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,14 @@ admin = User.where(email: 'admin@example.com').first_or_create(
   admin: true
 )
 
+manager = User.where(email: 'manager@example.com').first_or_create(
+  password: '123456',
+  full_name: 'Manager test',
+  cpf: FFaker::IdentificationBR.cpf,
+  cellphone: FFaker::PhoneNumber.short_phone_number,
+  address: FFaker::Address.street_address
+)
+
 regular = User.where(email: 'regular@example.com').first_or_create(
   password: '123456',
   full_name: 'Regular test',
@@ -20,4 +28,5 @@ company = Company.where(name: 'Company test').first_or_create(
   active: true
 )
 
-company.users << [admin, regular]
+company.managers << manager
+company.regulars << regular

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe Company, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_many(:users) }
+
+    it {
+      is_expected.to have_many(:managers)
+        .conditions(company_users: { role: :manager })
+        .through(:company_users)
+        .source(:user)
+    }
+
+    it {
+      is_expected.to have_many(:regulars)
+        .conditions(company_users: { role: :regular })
+        .through(:company_users)
+        .source(:user)
+    }
   end
 
   describe 'callbacks' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,4 +18,16 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:companies) }
     it { is_expected.to have_many(:company_users).dependent(:destroy) }
   end
+
+  describe 'scopes' do
+    describe '.admins' do
+      subject { described_class.admins }
+
+      let!(:admin) { create(:user, :admin) }
+      let!(:user) { create(:user) }
+
+      it { is_expected.to include(admin) }
+      it { is_expected.not_to include(user) }
+    end
+  end
 end

--- a/spec/policies/invoice_policy_spec.rb
+++ b/spec/policies/invoice_policy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe InvoicePolicy, type: :policy do
 
   let(:invoice) { build_stubbed(:invoice) }
 
-  context 'for a regular user' do
+  context 'when a regular user' do
     let(:user) { build_stubbed(:user) }
 
     it { is_expected.to authorize(:index) }
@@ -13,7 +13,7 @@ RSpec.describe InvoicePolicy, type: :policy do
     it { is_expected.not_to authorize(:update) }
   end
 
-  context 'for an admin user' do
+  context 'when an admin user' do
     let(:user) { build_stubbed(:user, :admin) }
 
     it { is_expected.to authorize(:index) }


### PR DESCRIPTION
#### What?

- allow `CompaniesController` to receive `manager_ids: []`, and `regular_ids: []`, as strong parameters

#### Why?

- this way the front-end apps can easily handle the forms, just build two arrays.

#### How it has been tested?

Happy flow:
![image](https://user-images.githubusercontent.com/47258878/152264371-4cee1948-ee6c-498c-9cb5-448d97c5d130.png)

Sad flow:
![image](https://user-images.githubusercontent.com/47258878/152264388-b883a306-c8be-462a-9fc3-2018efe35add.png)

