### PR TITLE
Adjust company_policy permitted_params

### DIFF
--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -1,5 +1,5 @@
 class CompanyPolicy < ApplicationPolicy
-  DEFAULT_ATTRS = %i[name cnpj address phone active].push(user_ids: [])
+  DEFAULT_ATTRS = %i[name cnpj address phone active].push(manager_ids: [], regular_ids: [])
   ADMIN_ATTRS = %i[discount].freeze
 
   class Scope < Scope

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -64,7 +64,8 @@ describe CompanyPolicy, type: :policy do
 
       it do
         is_expected.to match_array [
-          :name, :cnpj, :address, :phone, :active, { user_ids: [] }, :discount
+          :name, :cnpj, :address, :phone, :active, :discount,
+          { manager_ids: [], regular_ids: [] }
         ]
       end
     end
@@ -78,7 +79,10 @@ describe CompanyPolicy, type: :policy do
       end
 
       it do
-        is_expected.to match_array [:name, :cnpj, :address, :phone, :active, { user_ids: [] }]
+        is_expected.to match_array [
+          :name, :cnpj, :address, :phone, :active,
+          { manager_ids: [], regular_ids: [] }
+        ]
       end
     end
 
@@ -91,7 +95,10 @@ describe CompanyPolicy, type: :policy do
       end
 
       it do
-        is_expected.to match_array [:name, :cnpj, :address, :phone, :active, { user_ids: [] }]
+        is_expected.to match_array [
+          :name, :cnpj, :address, :phone, :active,
+          { manager_ids: [], regular_ids: [] }
+        ]
       end
     end
   end


### PR DESCRIPTION
References: https://github.com/comarev/comarev/pull/45

#### What?

- adjust company_policy to allow `manager_ids`, and `regular_ids`

#### Why?

- this way managers can update their companies, assign and unassign users

#### How it has been tested?

- sending an update request to `/companies/<id>`
