### PR TITLE
config recoverable password

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,13 @@
+class PasswordsController < Devise::PasswordsController
+  # POST /resource/password
+  def create
+    self.resource = resource_class.send_reset_password_instructions(resource_params)
+    yield resource if block_given?
+
+    if successfully_sent?(resource)
+      render json: { message: 'Reset password email was successfully sent' }, status: :ok
+    else
+      render json: { message: 'Reset password email could not be sent' }, status: :bad_request
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
-  devise :database_authenticatable,
-    :registerable, :jwt_authenticatable,
-    jwt_revocation_strategy: JwtDenylist
+  devise :database_authenticatable, :recoverable, 
+  :registerable, :jwt_authenticatable, 
+  jwt_revocation_strategy: JwtDenylist
 
   mount_uploader :avatar, AvatarUploader
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, 
-  :registerable, :jwt_authenticatable, 
-  jwt_revocation_strategy: JwtDenylist
+    :registerable, :jwt_authenticatable, 
+    jwt_revocation_strategy: JwtDenylist
 
   mount_uploader :avatar, AvatarUploader
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
-  devise :database_authenticatable, :recoverable, 
-    :registerable, :jwt_authenticatable, 
+  devise :database_authenticatable, :recoverable,
+    :registerable, :jwt_authenticatable,
     jwt_revocation_strategy: JwtDenylist
 
   mount_uploader :avatar, AvatarUploader

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { :host => "localhost:3000" }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { :host => "localhost:3000" }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,8 @@ Rails.application.configure do
   # config.active_storage.service = :test
 
   config.action_mailer.perform_caching = false
+  
+  config.action_mailer.default_url_options = { :host => "localhost:3000" }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   
-  config.action_mailer.default_url_options = { :host => "localhost:3000" }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users, skip: [:sessions, :registrations]
+  devise_for :users, skip: [:sessions, :registrations], controllers: { passwords: 'passwords'}
 
   as :user do
     post 'signup', to: 'registrations#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users, skip: [:sessions, :registrations], controllers: { passwords: 'passwords'}
+  devise_for :users, skip: [:sessions, :registrations], controllers: { passwords: 'passwords' }
 
   as :user do
     post 'signup', to: 'registrations#create'

--- a/spec/features/password_spec.rb
+++ b/spec/features/password_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe User, type: :request do
+  describe 'post /users/password' do
+    context 'with valid email' do
+      subject(:send_password_reset_email) do
+        post user_password_path, params: { user: {email: user.email}, format: :json}
+      end
+
+      let(:user) { create(:user) }
+
+      before do
+        send_password_reset_email
+      end
+      
+      it 'returns the correct 200 response code' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns the correct message' do
+        expect(json[:message]).to eq('Reset password email was successfully sent')
+      end
+
+      it 'sends reset password instructions email' do
+        expect(ActionMailer::Base.deliveries.count(1))
+      end
+
+      it 'sends the correct email' do
+        ActionMailer::Base.deliveries.first.subject.should == 'Instruções de troca de senha'
+      end
+    end
+    context 'with invalid email' do
+      subject(:send_password_reset_email_invalid) do
+        post user_password_path, params: { user: { }, format: :json}
+      end
+
+      before do
+        send_password_reset_email_invalid
+      end
+      
+      it 'returns the correct 200 response code' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns the correct message' do
+        expect(json[:message]).to eq('Reset password email could not be sent')
+      end
+
+      it "Doesn't send reset password instructions email" do
+        expect(ActionMailer::Base.deliveries.count(0))
+      end
+    end
+  end
+end

--- a/spec/features/user_password_spec.rb
+++ b/spec/features/user_password_spec.rb
@@ -12,7 +12,7 @@ describe User, type: :request do
       before do
         send_password_reset_email
       end
-      
+
       it 'returns the correct 200 response code' do
         expect(response).to have_http_status(:ok)
       end
@@ -22,22 +22,23 @@ describe User, type: :request do
       end
 
       it 'sends reset password instructions email' do
-        expect(ActionMailer::Base.deliveries.count(1))
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
       end
 
       it 'sends the correct email' do
         ActionMailer::Base.deliveries.first.subject.should == 'Instruções de troca de senha'
       end
     end
+
     context 'with invalid email' do
       subject(:send_password_reset_email_invalid) do
-        post user_password_path, params: { user: { }, format: :json }
+        post user_password_path, params: { user: { email: '' }, format: :json }
       end
 
       before do
         send_password_reset_email_invalid
       end
-      
+
       it 'returns the correct 200 response code' do
         expect(response).to have_http_status(:bad_request)
       end
@@ -47,7 +48,7 @@ describe User, type: :request do
       end
 
       it "Doesn't send reset password instructions email" do
-        expect(ActionMailer::Base.deliveries.count(0))
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
     end
   end

--- a/spec/features/user_password_spec.rb
+++ b/spec/features/user_password_spec.rb
@@ -4,7 +4,7 @@ describe User, type: :request do
   describe 'post /users/password' do
     context 'with valid email' do
       subject(:send_password_reset_email) do
-        post user_password_path, params: { user: {email: user.email}, format: :json}
+        post user_password_path, params: { user: { email: user.email }, format: :json }
       end
 
       let(:user) { create(:user) }
@@ -31,7 +31,7 @@ describe User, type: :request do
     end
     context 'with invalid email' do
       subject(:send_password_reset_email_invalid) do
-        post user_password_path, params: { user: { }, format: :json}
+        post user_password_path, params: { user: { }, format: :json }
       end
 
       before do


### PR DESCRIPTION
<!-- Thanks for sending a pr to comarev :D -->
<!-- what github issue is this PR for, if any? -->

Closes: #70 

#### What?

- Set password to recoverable and configure mailer to send reset password instructions

#### Why?

- Users need to reset password if forgotten without the need to contact a administrator

#### How to test it?

- Rspec tests were implemented

#### Sent email (catched with MailTrap):
![image](https://user-images.githubusercontent.com/36737050/161305356-c17d8ce5-548e-47de-8106-bd2e5dfb9a21.png)
