### PR TITLE
Add GH issue_templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+### Impacted User Types
+
+- admins?
+- managers?
+- regulars?
+- contributors?
+
+### Environment
+
+ex: local, staging, postman, insomnia, etc.
+
+### Current Behavior
+
+ex: logged with an admin, I should see all companies
+
+### Expected Behavior
+
+ex: logged with a regular user, I can see just one company
+
+### How to Replicate
+
+ex:
+
+1. - Log into staging as an admin or manager.
+2. - Make a request to `/api/v1/some-path`
+3. - ...

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,5 @@
+**Description**
+
+**Existing gem(s), file(s) needing updating, changing or deleting**
+
+**New file(s) needing creating**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug report
+    about: What needs fixing?
+    url: https://github.com/comarev/comarev/issues/new?template=bug_report.md&projects=comarev/comarev/1
+  - name: Feature request
+    about: What needs building?
+    url: https://github.com/comarev/comarev/issues/new?template=feature_request.md&projects=comarev/comarev/1
+  - name: Documentation addition/change
+    about: What needs documenting?
+    url: https://github.com/comarev/comarev/issues/new?template=documentation.md&projects=comarev/comarev/1
+  - name: Chore
+    about: What needs updating or removing?
+    url: https://github.com/comarev/comarev/issues/new?template=chore.md&projects=comarev/comarev/1

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,5 @@
+**Description**
+
+**Existing file(s) needing changing**
+
+**New file(s) needing creating**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+**What type(s) of user does this feature affect?**
+
+- admins?
+- managers?
+- regulars?
+- contributors?
+
+**Description**
+
+**Screenshots of current behavior, if any**
+You can paste images on the clipboard here


### PR DESCRIPTION
#### What?

- Add GitHub issue_templates

#### Why?

- To become easier to report new issues
