### PR TITLE
[#69] Add approval flow for new customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Run tests:
 
     bundle exec rspec
 
+After running the server, you can also preview the emails at http://localhost:3000/rails/mailers.
+
 ### Setup with docker
 
 You will need to install [docker-compose](https://docs.docker.com/compose/install/)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,6 +3,7 @@ class RegistrationsController < Devise::RegistrationsController
   PERMITTED_PARAMS = %i[email full_name cellphone cpf address].freeze
 
   before_action :configure_permitted_parameters
+  after_action :send_user_self_registration_notification_email, only: %i[create] # rubocop:disable Rails/LexicallyScopedActionFilter
 
   respond_to :json
 
@@ -14,5 +15,14 @@ class RegistrationsController < Devise::RegistrationsController
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: PERMITTED_PARAMS)
+  end
+
+  def send_user_self_registration_notification_email
+    return unless resource.persisted?
+
+    AdminMailer.user_self_registration_notification(
+      admin_emails: User.admins.pluck(:email),
+      user: resource
+    ).deliver_later
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,18 @@
+class RegistrationsController < Devise::RegistrationsController
+  DEFAULT_REGISTRATION_PARAMS = { active: false, self_registered: true }.freeze
+  PERMITTED_PARAMS = %i[email full_name cellphone cpf address].freeze
+
+  before_action :configure_permitted_parameters
+
+  respond_to :json
+
+  private
+
+  def build_resource(params = {})
+    super(params.merge(DEFAULT_REGISTRATION_PARAMS))
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: PERMITTED_PARAMS)
+  end
+end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,7 @@
+class AdminMailer < ApplicationMailer
+  def user_self_registration_notification(admin_emails:, user:)
+    @user = user
+
+    mail(to: admin_emails, subject: default_i18n_subject(name: user.full_name))
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
-  devise :database_authenticatable, :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
+  devise :database_authenticatable,
+    :registerable, :jwt_authenticatable,
+    jwt_revocation_strategy: JwtDenylist
 
   mount_uploader :avatar, AvatarUploader
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -8,6 +8,7 @@ class UserSerializer < ActiveModel::Serializer
     :picture_url,
     :admin,
     :active,
+    :self_registered,
     :created_at,
     :updated_at
 

--- a/app/views/admin_mailer/user_self_registration_notification.html.erb
+++ b/app/views/admin_mailer/user_self_registration_notification.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+</head>
+<body>
+  <p><%= t('admin_mailer.user_self_registration_notification.heading') %></p>
+
+  <p><%= t('admin_mailer.user_self_registration_notification.body') %> <strong><%= @user.email %></strong></p>
+
+  <p><%= t('admin_mailer.user_self_registration_notification.conclusion') %></p>
+</body>
+</html>

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -229,3 +229,9 @@ pt-BR:
     pm: ""
   pundit:
     default: "Você não possui autorização!"
+  admin_mailer:
+    user_self_registration_notification:
+      subject: Novo usuário cadastrado - %{name}
+      heading: Um novo usuário se cadastrou no sistema.
+      body: O e-mail do novo usuário é
+      conclusion: Para que o usuário seja capaz de acessar o sistema, ele deverá ser ativado manualmente.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users, skip: [:sessions]
+  devise_for :users, skip: [:sessions, :registrations]
 
   as :user do
+    post 'signup', to: 'registrations#create'
     post 'login', to: 'sessions#create'
     delete 'logout', to: 'sessions#destroy'
   end

--- a/db/migrate/20220322182124_add_self_registered_to_users.rb
+++ b/db/migrate/20220322182124_add_self_registered_to_users.rb
@@ -1,0 +1,5 @@
+class AddSelfRegisteredToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :self_registered, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_03_232114) do
+ActiveRecord::Schema.define(version: 2022_03_22_182124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,6 +104,7 @@ ActiveRecord::Schema.define(version: 2022_03_03_232114) do
     t.boolean "admin", default: false, null: false
     t.boolean "active", default: true, null: false
     t.string "avatar"
+    t.boolean "self_registered", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe AdminMailer, type: :mailer do
+  describe '#user_self_registration_notification' do
+    subject(:email) do
+      described_class.user_self_registration_notification(user: user, admin_emails: [admin.email])
+    end
+
+    let(:user) { build_stubbed(:user, self_registered: true) }
+    let(:admin) { build_stubbed(:user, :admin) }
+
+    it 'delivers the email' do
+      expect { email.deliver_now }.to change(described_class.deliveries, :count).by(1)
+    end
+
+    it 'shows correct messages', :aggregate_failures do
+      expect(email.to).to eq [admin.email]
+      expect(email.from).to eq ['from@example.com']
+      expect(email.subject).to eq "Novo usuário cadastrado - #{user.full_name}"
+
+      expect(email.body).to include('Um novo usuário se cadastrou no sistema.')
+      expect(email.body).to include("O e-mail do novo usuário é <strong>#{user.email}</strong>")
+
+      expect(email.body).to include(
+        'Para que o usuário seja capaz de acessar o sistema, '\
+        'ele deverá ser ativado manualmente.'
+      )
+    end
+  end
+end

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -1,0 +1,8 @@
+class AdminMailerPreview < ActionMailer::Preview
+  def user_self_registration_notification
+    admin = FactoryBot.build_stubbed(:user, :admin)
+    user = FactoryBot.build_stubbed(:user)
+
+    AdminMailer.user_self_registration_notification(admin_emails: [admin.email], user: user)
+  end
+end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe 'Registrations', type: :request do
         it 'creates a new record in the database' do
           expect { request }.to change(User, :count).by(1)
         end
+
+        it 'sends an email to the admins', :aggregate_failures do
+          expect do
+            request
+          end.to have_enqueued_mail(AdminMailer, :user_self_registration_notification)
+        end
       end
 
       context 'with invalid params' do
@@ -48,6 +54,12 @@ RSpec.describe 'Registrations', type: :request do
 
           expect(json).to eq(errors: { full_name: ['não pode ficar em branco'] })
           expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'does not send an email to the admins', :aggregate_failures do
+          expect do
+            request
+          end.not_to have_enqueued_mail(AdminMailer, :user_self_registration_notification)
         end
       end
 
@@ -73,6 +85,12 @@ RSpec.describe 'Registrations', type: :request do
 
           expect(json).to eq expected_body
           expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'does not send an email to the admins', :aggregate_failures do
+          expect do
+            request
+          end.not_to have_enqueued_mail(AdminMailer, :user_self_registration_notification)
         end
       end
     end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe 'Registrations', type: :request do
+  describe 'POST /signup' do
+    subject(:request) { post signup_path, params: params, as: :json }
+
+    context 'without logged in user', :aggregate_failures do
+      context 'with valid params' do
+        let(:params) { { user: attributes_for(:user, full_name: 'Mary Jane') } }
+
+        let(:new_user) { User.last }
+
+        let(:expected_body) do
+          {
+            active: false,
+            address: new_user.address,
+            admin: false,
+            cellphone: new_user.cellphone,
+            companies: [],
+            cpf: new_user.cpf,
+            created_at: new_user.created_at.iso8601(3),
+            email: new_user.email,
+            full_name: new_user.full_name,
+            id: new_user.id,
+            picture_url: nil,
+            self_registered: true,
+            updated_at: new_user.updated_at.iso8601(3)
+          }
+        end
+
+        it 'shows success message' do
+          request
+
+          expect(json).to eq expected_body
+          expect(response).to be_successful
+        end
+
+        it 'creates a new record in the database' do
+          expect { request }.to change(User, :count).by(1)
+        end
+      end
+
+      context 'with invalid params' do
+        let(:params) { { user: attributes_for(:user, full_name: nil) } }
+
+        it 'shows invalid params message' do
+          request
+
+          expect(json).to eq(errors: { full_name: ['não pode ficar em branco'] })
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context 'without params' do
+        let(:params) { {} }
+        let(:expected_body) do
+          {
+            errors: {
+              email: ['não pode ficar em branco'],
+              full_name: ['não pode ficar em branco'],
+              cellphone: [
+                'não pode ficar em branco',
+                'não possui o tamanho esperado (15 caracteres)'
+              ],
+              address: ['não pode ficar em branco'],
+              cpf: ['não pode ficar em branco', 'não possui o tamanho esperado (11 caracteres)']
+            }
+          }
+        end
+
+        it 'shows invalid params message' do
+          request
+
+          expect(json).to eq expected_body
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for sending a pr to comarev :D -->
<!-- what github issue is this PR for, if any? -->

Closes: #69 

<!-- if this pr is not closing the issue, but it is related somehow -->

#### What?

- Add a new attribute to the `users` table: `self_registered`
- Add a way for unauthenticated users to register themselves in the platform
- When a user registers themselves, an email is sent to all admins notifying about the new user and their email address
- Self registered users have, by default, `self_registered: true` and `active: false` and need to be enabled manually by an admin

#### Why?

With these changes, admins no longer need to manually add each user to the platform, they only need to approve their entry.

#### How to test it?
Open up the application and create a new user via the JSON request `POST /signup` with the body:
```json
{
  "user": {
    "full_name": "John Doe",
    "email": "user@example.org",
    "password": "12345678",
    "address": "Test Street, 123",
    "cpf": "12345670088",
    "cellphone": "123456789012345"
  }
}
```
Example cURL request:
```console
curl -v -X POST http://localhost:3000/signup.json \
  -H 'Content-Type: application/json' \
  -d '{
    "user": {
      "full_name": "John Doe",
      "email": "user@example.org",
      "password": "12345678",
      "address": "Test Street, 123",
      "cpf": "12345670088",
      "cellphone": "123456789012345"
    }
  }'
```

It should return status `201 Created` and a body containing the created user:
```json
{
  "id": 5,
  "full_name": "John Doe",
  "email": "user@example.org",
  "cpf": "12345670088",
  "address": "Test Street, 123",
  "cellphone": "123456789012345",
  "picture_url": null,
  "admin": false,
  "active": false,
  "self_registered": true,
  "created_at": "2022-03-23T17:10:05.768Z",
  "updated_at": "2022-03-23T17:10:05.768Z",
  "companies": []
}
```

If something is wrong, it will return `422 Unprocessable Entity` with the errors inside the body:
```json
{
  "errors": {
    "email": [
      "já está em uso"
    ],
    "cpf": [
      "já está em uso"
    ]
  }
}
```

#### Mailer Preview Screenshot
![oss-comarev-69-email](https://user-images.githubusercontent.com/72531802/159754756-d9a6edd6-9fd2-4c88-af27-9cf0b505fcf8.png)

