### PR TITLE
(Feat)create discount request on check fail

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -29,11 +29,12 @@ class InvoicesController < ApplicationController
     authorize(Invoice)
     @company = Company.find_by!(code: params[:code])
     all_paid = policy_scope(Invoice).all?(&:paid?)
+    discount = 0 unless all_paid
 
     DiscountRequest.create!(
       company: @company,
       user: current_user,
-      received_discount: @company.discount,
+      received_discount: discount || @company.discount,
       allowed: all_paid
     )
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,6 +26,7 @@ regular = User.where(email: 'regular@example.com').first_or_create(
 company = Company.where(name: 'Company test').first_or_create(
   cnpj: FFaker::IdentificationBR.cnpj,
   phone: FFaker.numerify('#' * 14),
+  discount: FFaker.rand(10),
   active: true
 )
 

--- a/spec/requests/invoice_spec.rb
+++ b/spec/requests/invoice_spec.rb
@@ -134,6 +134,12 @@ RSpec.describe Invoice, type: :request do
         expect { check_invoice }.to change(DiscountRequest, :count).by(1)
       end
 
+      it 'creates a DiscountRequest with received_discount = 0' do
+        check_invoice
+
+        expect(DiscountRequest.last.received_discount).to eq(0)
+      end
+
       it 'returns the correct', :aggregate_failures do
         check_invoice
 


### PR DESCRIPTION
<!-- Thanks for sending a pr to comarev :D -->
<!-- what github issue is this PR for, if any? -->

Closes: #53 

This PR was mostly done, but it was not setting the received_discount to 0

#### What?
- When unpaid invoices exist, the received discount of the request is set to 0

#### How to test it?

A rspec test was created, to run it:
<code>bundle exec rspec spec/requests/invoice_spec.rb:137<code>

