### PR TITLE
Update github actions to run on main branch

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,11 +3,11 @@ name: RSpec
 on:
   push:
     branches:
-      - master
+      - main
       - staging
   pull_request:
     branches:
-      - master
+      - main
       - staging
 
 jobs:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,11 +3,11 @@ name: Rubocop
 on:
   push:
     branches:
-      - master
+      - main
       - staging
   pull_request:
     branches:
-      - master
+      - main
       - staging
 
 jobs:
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.3.4
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7.0
-        bundler-cache: true
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.0
+          bundler-cache: true
 
-    - name: linter
-      run: bundle exec rubocop
+      - name: linter
+        run: bundle exec rubocop


### PR DESCRIPTION
#### What?

- Update GitHub actions, since we updated the default branch from `master` to `main`

#### Why?

- to keep running the GitHub actions for `rubocop` and `rspec`

