### PR TITLE
Add swagger doc for sign in path

### DIFF
--- a/config/swagger.json
+++ b/config/swagger.json
@@ -23,6 +23,10 @@
     {
       "name": "Company",
       "description": "Operations about company and discount requests"
+    },
+    {
+      "name": "Sign in",
+      "description": "Operation about sign in with all user roles"
     }
   ],
   "schemes": ["https", "http"],
@@ -58,6 +62,38 @@
           },
           "404": {
             "description": "company not found"
+          }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "tags": ["Sign in"],
+        "summary": "Given the email and password, returns a JWT of the signed user",
+        "operationId": "signIn",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "user[email]",
+            "in": "formData",
+            "description": "Participant's email",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "user[password]",
+            "in": "formData",
+            "description": "Participant's password",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          },
+          "401": {
+            "description": "invalid email or password"
           }
         }
       }


### PR DESCRIPTION
<!-- Thanks for sending a pr to comarev :D -->
<!-- what github issue is this PR for, if any? -->

Closes: https://github.com/comarev/comarev/issues/122

<!-- if this pr is not closing the issue, but it is related somehow -->

#### What?

- add sign in swagger doc

#### Why?

- to improve api reading XP

#### How to test it?

- browse to `/docs`

![image](https://user-images.githubusercontent.com/47258878/197410026-7032932c-976a-4141-85ee-539d4531dd9e.png)

![image](https://user-images.githubusercontent.com/47258878/197410042-6581ed58-ec6c-4efb-845b-739004a40514.png)
